### PR TITLE
Improved handling of device attributes.

### DIFF
--- a/client.go
+++ b/client.go
@@ -85,7 +85,7 @@ func (c Client) DeviceList() (devices []Device, err error) {
 		}
 
 		fields := strings.Fields(line)
-		if len(fields) < 5 || len(fields[0]) == 0 {
+		if len(fields) < 4 || len(fields[0]) == 0 {
 			debugLog(fmt.Sprintf("can't parse: %s", line))
 			continue
 		}
@@ -94,6 +94,9 @@ func (c Client) DeviceList() (devices []Device, err error) {
 		mapAttrs := map[string]string{}
 		for _, field := range sliceAttrs {
 			split := strings.Split(field, ":")
+			if len(split) == 1 {
+				continue
+			}
 			key, val := split[0], split[1]
 			mapAttrs[key] = val
 		}

--- a/device.go
+++ b/device.go
@@ -59,20 +59,37 @@ type Device struct {
 	attrs     map[string]string
 }
 
-func (d Device) Product() string {
-	return d.attrs["product"]
+func (d Device) HasAttribute(key string) bool {
+	_, ok := d.attrs[key]
+	return ok
 }
 
-func (d Device) Model() string {
-	return d.attrs["model"]
+func (d Device) Product() (string, error) {
+	if d.HasAttribute("product") {
+		return d.attrs["product"], nil
+	}
+	return "", errors.New("does not have attribute: product")
 }
 
-func (d Device) Usb() string {
-	return d.attrs["usb"]
+func (d Device) Model() (string, error) {
+	if d.HasAttribute("model") {
+		return d.attrs["model"], nil
+	}
+	return "", errors.New("does not have attribute: model")
 }
 
-func (d Device) transportId() string {
-	return d.attrs["transport_id"]
+func (d Device) Usb() (string, error) {
+	if d.HasAttribute("usb") {
+		return d.attrs["usb"], nil
+	}
+	return "", errors.New("does not have attribute: usb")
+}
+
+func (d Device) transportId() (string, error) {
+	if d.HasAttribute("transport_id") {
+		return d.attrs["transport_id"], nil
+	}
+	return "", errors.New("does not have attribute: transport_id")
 }
 
 func (d Device) DeviceInfo() map[string]string {
@@ -84,8 +101,13 @@ func (d Device) Serial() string {
 	return d.serial
 }
 
-func (d Device) IsUsb() bool {
-	return d.Usb() != ""
+func (d Device) IsUsb() (bool, error) {
+	usb, err := d.Usb()
+	if err != nil {
+		return false, err
+	}
+
+	return usb != "", nil
 }
 
 func (d Device) State() (DeviceState, error) {


### PR DESCRIPTION
I encountered an edge case when using this package, where the `devices-l` command gave an output that looked like this:
```
R9KR*******            unauthorized 0-1.4.1.3 transport_id:3
```

I noticed that the attributes were not used anywhere that seemed important, so I enabled the device parser to handle this condition, and made attribute struct methods error-able if the corresponding key is not found.