### PR TITLE
Fix usage of time.Duration

### DIFF
--- a/sync_transport.go
+++ b/sync_transport.go
@@ -240,7 +240,7 @@ func (sync syncTransport) ReadStringN(size int) (s string, err error) {
 }
 
 func (sync syncTransport) ReadBytesN(size int) (raw []byte, err error) {
-	_ = sync.sock.SetReadDeadline(time.Now().Add(time.Second * sync.readTimeout))
+	_ = sync.sock.SetReadDeadline(time.Now().Add(sync.readTimeout))
 	return _readN(sync.sock, size)
 }
 

--- a/transport.go
+++ b/transport.go
@@ -12,7 +12,7 @@ import (
 
 var ErrConnBroken = errors.New("socket connection broken")
 
-var DefaultAdbReadTimeout time.Duration = 60
+var DefaultAdbReadTimeout time.Duration = 60 * time.Second
 
 type transport struct {
 	sock        net.Conn
@@ -97,7 +97,7 @@ func (t transport) ReadStringN(size int) (s string, err error) {
 }
 
 func (t transport) ReadBytesN(size int) (raw []byte, err error) {
-	_ = t.sock.SetReadDeadline(time.Now().Add(time.Second * t.readTimeout))
+	_ = t.sock.SetReadDeadline(time.Now().Add(t.readTimeout))
 	return _readN(t.sock, size)
 }
 


### PR DESCRIPTION
The Duration type contains a specific amount of time, and should not be treated as an integer number of seconds.

Set DefaultAdbReadTimeout to 60 seconds, and don't multiply the usage of durations by time.Second.