### PR TITLE
Logcat

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -1,0 +1,23 @@
+package gadb
+
+import (
+	"context"
+	"io"
+)
+
+type readerCtx struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (r *readerCtx) Read(p []byte) (n int, err error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.r.Read(p)
+}
+
+// NewReader gets a context-aware io.Reader.
+func NewReader(ctx context.Context, r io.Reader) io.Reader {
+	return &readerCtx{ctx: ctx, r: r}
+}


### PR DESCRIPTION
**Support logcat command**
Add Logcat / Logcat2File / LogcatClear in device.go.
Origin RunShellCommand in device.go is not support continuous output command.